### PR TITLE
Fix concurrency issue in dayCount

### DIFF
--- a/src/ExcelFinancialFunctions/common.fs
+++ b/src/ExcelFinancialFunctions/common.fs
@@ -119,13 +119,15 @@ module internal Common =
         else
             let lower, upper = findBounds f guess -1.0 Double.MaxValue precision
             bisection f lower upper 0 precision
-            
+     
     let memoize f =
         let m = new Dictionary<_,_> ()
         fun x ->
-                let foundIt, res = m.TryGetValue(x)
-                if foundIt then res
-                else
-                    let r = f x
-                    m.Add(x, r)
-                    r
+                lock m (fun () ->
+                    let foundIt, res = m.TryGetValue(x)
+                    if foundIt then res
+                    else
+                        let r = f x
+                        m.Add(x, r)
+                        r
+                )

--- a/tests/ExcelFinancialFunctions.Tests/ExcelFinancialFunctions.Tests.fsproj
+++ b/tests/ExcelFinancialFunctions.Tests/ExcelFinancialFunctions.Tests.fsproj
@@ -43,6 +43,7 @@
     <Compile Include="testutils.fs" />
     <Compile Include="crosstests.fs" />
     <Compile Include="spottests.fs" />
+    <Compile Include="concurrencytests.fs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="ExcelFinancialFunctions">

--- a/tests/ExcelFinancialFunctions.Tests/concurrencytests.fs
+++ b/tests/ExcelFinancialFunctions.Tests/concurrencytests.fs
@@ -1,0 +1,65 @@
+﻿namespace Excel.FinancialFunctions.Tests
+
+open NUnit.Framework
+
+// These tests check that nothing goes wrong with the memoization which is used in the internal dayCount function
+// that is called by the functions tested below - when used concurrently.
+
+[<SetCulture("en-US")>]
+module ConcurrencyTests =
+    open System 
+    open Excel.FinancialFunctions
+    open TestPreconditions
+
+    let parallelCount = 8
+
+    let TestParallel (f : unit -> unit) =
+        let expected = true
+        let actual =
+            try
+                [|1..parallelCount|]
+                |> Array.Parallel.iter (fun _ -> f())
+                true
+            with    
+            | _ -> false
+
+        Assert.AreEqual(expected, actual)
+
+    let startDate = DateTime(2000, 1, 1)
+    let endDate = DateTime(2010, 1, 1)
+
+    [<Test>]
+    let YearFracWorksConcurrently() =
+        let f = fun () -> (Financial.YearFrac(startDate, endDate, DayCountBasis.Actual365) |> ignore)
+        TestParallel f
+
+    [<Test>]
+    let CoupDaysWorksConcurrently() =
+        let f = fun () -> (Financial.CoupDays(startDate, endDate, Frequency.Quarterly, DayCountBasis.Actual365) |> ignore)
+        TestParallel f
+
+    [<Test>]
+    let CoupPCDWorksConcurrently() =
+        let f = fun () -> (Financial.CoupPCD(startDate, endDate, Frequency.Quarterly, DayCountBasis.Actual365) |> ignore)
+        TestParallel f
+
+    [<Test>]
+    let CoupNCDWorksConcurrently() =
+        let f = fun () -> (Financial.CoupNCD(startDate, endDate, Frequency.Quarterly, DayCountBasis.Actual365) |> ignore)
+        TestParallel f
+
+    [<Test>]
+    let CoupNumWorksConcurrently() =
+        let f = fun () -> (Financial.CoupNum(startDate, endDate, Frequency.Quarterly, DayCountBasis.Actual365) |> ignore)
+        TestParallel f
+
+    [<Test>]
+    let CoupDaysBSWorksConcurrently() =
+        let f = fun () -> (Financial.CoupDaysBS(startDate, endDate, Frequency.Quarterly, DayCountBasis.Actual365) |> ignore)
+        TestParallel f
+
+    [<Test>]
+    let CoupDaysNCWorksConcurrently() =
+        let f = fun () -> (Financial.CoupDaysNC(startDate, endDate, Frequency.Quarterly, DayCountBasis.Actual365) |> ignore)
+        TestParallel f
+


### PR DESCRIPTION
The dayCount function was memoized, but there was no lock on the
memoization dictionary, so several of the date functions would fail when
called concurrently.  Added tests to show this, and fixed the actual
issue.
