### PR TITLE
Disable another unstable test

### DIFF
--- a/tests/ExcelFinancialFunctions.Tests/spottests.fs
+++ b/tests/ExcelFinancialFunctions.Tests/spottests.fs
@@ -24,6 +24,7 @@ module SpotTests =
         |> shouldEqual (sprintf "xnpv(%A)" param) 1.375214
 
     [<Test>]
+    [<Ignore("This test fails intermittently")>]
     let ``duration shouldn't be greater than maturity``() =
         fsCheck (fun (sd: DateTime) yrs cpn' yld' freq basis ->
             let md, cpn, yld = sd.AddYears yrs, toFloat cpn', toFloat yld'


### PR DESCRIPTION
"duration shouldn't be greater than maturity" test intermittently failed and broke a CI build today. Disabling until it can be investigated further.