### PR TITLE
Add multi-framework support: netstandard2.1, net8.0, net10.0

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -8,11 +8,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: |
+          8.0.x
+          10.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -8,11 +8,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: |
+          8.0.x
+          10.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build Debug

--- a/src/ExcelFinancialFunctions/ExcelFinancialFunctions.fsproj
+++ b/src/ExcelFinancialFunctions/ExcelFinancialFunctions.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net10.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <WarnOn>3390;$(WarnOn)</WarnOn>

--- a/src/ExcelFinancialFunctions/common.fs
+++ b/src/ExcelFinancialFunctions/common.fs
@@ -39,7 +39,7 @@ module internal Common =
            
     // Date functions
     let days (after:DateTime) (before:DateTime) = (after - before).Days
-    let date y m d = new DateTime(y, m, d)
+    let date (y: int) (m: int) (d: int) = new DateTime(y, m, d)
     let (|Date|) (d1:DateTime) = (d1.Year,d1.Month,d1.Day)
     let isLeapYear (Date(y,_,_) as d) = DateTime.IsLeapYear(y)
     let leapYear y = DateTime.IsLeapYear(y)

--- a/tests/ExcelFinancialFunctions.Tests/ExcelFinancialFunctions.Tests.fsproj
+++ b/tests/ExcelFinancialFunctions.Tests/ExcelFinancialFunctions.Tests.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>


### PR DESCRIPTION
Adds multi-targeting to the main library and upgrades the test/CI stack from the EOL netcoreapp6.0/.NET 6 baseline.

## Changes

- **`ExcelFinancialFunctions.fsproj`** — `TargetFramework` → `TargetFrameworks`: `netstandard2.0;netstandard2.1;net8.0;net10.0` (retains `netstandard2.0` for backward compat)
- **`ExcelFinancialFunctions.Tests.fsproj`** — `netcoreapp6.0` → `net8.0`
- **CI workflows** (`pull-requests.yml`, `push-master.yml`) — `dotnet-version: 6.0.x` → `8.0.x + 10.0.x`; `actions/checkout@v2` → `@v4`; `actions/setup-dotnet@v1` → `@v4`
- **`common.fs`** — Fixes `FS0041` overload ambiguity on `DateTime` introduced in .NET 8, which added a `DateTime(DateOnly, TimeOnly, DateTimeKind)` overload that confuses the F# compiler when argument types are unresolved:

```fsharp
// Before — ambiguous in .NET 8+
let date y m d = new DateTime(y, m, d)

// After
let date (y: int) (m: int) (d: int) = new DateTime(y, m, d)
```